### PR TITLE
2 Map function examples

### DIFF
--- a/dags/2_4_example_dag_map_function.py
+++ b/dags/2_4_example_dag_map_function.py
@@ -1,0 +1,50 @@
+"""Example DAG showing the use of the .map method."""
+
+from airflow import DAG
+from datetime import datetime
+from airflow.exceptions import AirflowSkipException
+from airflow.providers.amazon.aws.operators.s3 import S3ListOperator
+from airflow.providers.amazon.aws.operators.s3 import S3DeleteObjectsOperator
+
+"""
+This DAG shows an example implementation of dynamically mapping over an
+S3DeleteObjectsOperator and skipping deletion of certain files based on their
+filetype using a .map mapping. This type of mapping was added in Airflow 2.4.
+
+The first task 'list_files_S3' lists all files in S3_BUCKET. Instead of passing
+the input directly to the deletion task a mapping step is used in between,
+using the map_files_for_deletion function. This function will not create an
+Airflow task.
+map_files_for_deletion maps all files of the type json, yml and txt to an
+Airflow exception causing these files to be skipped in the deletion task.
+
+The delete_files task is dynamically mapped over the transformed list of files.
+"""
+
+S3_BUCKET = "your S3 bucket"
+
+with DAG(
+    dag_id="2_4_example_dag_map_function",
+    start_date=datetime(2022, 10, 1),
+    schedule=None,
+    catchup=False
+):
+
+    list_files_S3 = S3ListOperator(
+        task_id="list_files_S3",
+        aws_conn_id="aws_conn",
+        bucket=S3_BUCKET
+    )
+
+    def map_files_for_deletion(filename):
+        if filename.rsplit(".", 1)[-1] in ("json", "yml", "txt"):
+            raise AirflowSkipException(f"Skip deletion to keep {filename}")
+        return filename
+
+    deletion_map = list_files_S3.output.map(map_files_for_deletion)
+
+    delete_files = S3DeleteObjectsOperator.partial(
+        task_id="delete_files",
+        aws_conn_id="aws_conn",
+        bucket=S3_BUCKET
+    ).expand(keys=deletion_map)

--- a/dags/2_4_example_toy_dag_map_function.py
+++ b/dags/2_4_example_toy_dag_map_function.py
@@ -1,0 +1,51 @@
+"""Toy example DAG showing how the .map method works.
+
+This example shows the syntax and workings of using the .map function on 
+the output of a task. 
+list_objects simulates getting outputs of a fixed format. map_objects is 
+a function transforming the output of list objects to return an 
+AirflowSkipException for all strings starting with "skip". 
+The mapped task mapped_printing_function maps on the transformed output, 
+resulting in the mapped task instances 0 and 2 to be skipped.
+"""
+
+from airflow import DAG
+from airflow.decorators import task
+from datetime import datetime
+from airflow.exceptions import AirflowSkipException
+
+with DAG(
+    dag_id="2_4_example_toy_dag_map_function",
+    start_date=datetime(2022, 10, 1),
+    schedule=None,
+    catchup=False
+):
+
+    # an upstream task returns a list of outputs in a fixed format
+    @task
+    def list_strings():
+        return ["skip_hello", "hi", "skip_hallo", "hola", "hey"]
+
+    # the function used to transform the upstream output before 
+    # a downstream task is dynamically mapped over it
+    def skip_strings_starting_with_skip(string):
+        if len(string) < 4:
+            return string + " !"
+        elif string[:4] == "skip":
+            raise AirflowSkipException(
+                f"Skipping {string}; as I was told!"
+            )
+        else:
+            return string + " !"
+            
+    # transforming the output of the first task with the map function
+    # for non-TaskFlow operators use 
+    # my_upstream_traditional_operator.output.map(mapping_function)
+    transformed_list = list_strings().map(skip_strings_starting_with_skip)
+
+    # the task using dynamic task mapping on the transformed list of strings
+    @task
+    def mapped_printing_function(string):
+        return "Say " + string 
+
+    mapped_printing_function.partial().expand(string=transformed_list)

--- a/dags/2_4_example_toy_dag_map_function.py
+++ b/dags/2_4_example_toy_dag_map_function.py
@@ -1,11 +1,11 @@
 """Toy example DAG showing how the .map method works.
 
-This example shows the syntax and workings of using the .map function on 
-the output of a task. 
-list_objects simulates getting outputs of a fixed format. map_objects is 
-a function transforming the output of list objects to return an 
-AirflowSkipException for all strings starting with "skip". 
-The mapped task mapped_printing_function maps on the transformed output, 
+This example shows the syntax and workings of using the .map function on
+the output of a task.
+list_objects simulates getting outputs of a fixed format. map_objects is
+a function transforming the output of list objects to return an
+AirflowSkipException for all strings starting with "skip".
+The mapped task mapped_printing_function maps on the transformed output,
 resulting in the mapped task instances 0 and 2 to be skipped.
 """
 
@@ -26,26 +26,26 @@ with DAG(
     def list_strings():
         return ["skip_hello", "hi", "skip_hallo", "hola", "hey"]
 
-    # the function used to transform the upstream output before 
+    # the function used to transform the upstream output before
     # a downstream task is dynamically mapped over it
     def skip_strings_starting_with_skip(string):
         if len(string) < 4:
-            return string + " !"
+            return string + "!"
         elif string[:4] == "skip":
             raise AirflowSkipException(
                 f"Skipping {string}; as I was told!"
             )
         else:
-            return string + " !"
-            
+            return string + "!"
+
     # transforming the output of the first task with the map function
-    # for non-TaskFlow operators use 
+    # for non-TaskFlow operators use
     # my_upstream_traditional_operator.output.map(mapping_function)
     transformed_list = list_strings().map(skip_strings_starting_with_skip)
 
     # the task using dynamic task mapping on the transformed list of strings
     @task
     def mapped_printing_function(string):
-        return "Say " + string 
+        return "Say " + string
 
     mapped_printing_function.partial().expand(string=transformed_list)


### PR DESCRIPTION
PR contains two new DAGs using the `.map()` function. One is a toy example not using any connections and showing the syntax as simple as possible. The other one is a real world example showing how to skip certain inputs in a dynamically mapped task by using .map on the iterable of inputs. 